### PR TITLE
Updates to the list of approved FQDNs

### DIFF
--- a/app-fqdn-rules.tf
+++ b/app-fqdn-rules.tf
@@ -4,6 +4,7 @@ locals {
     tcp = {
       "*.aviatrix.com" = "443"
       "aviatrix.com"   = "80"
+      "*.ubuntu.com"   = "80"
     }
     udp = {
       "dns.google.com" = "53"


### PR DESCRIPTION
Add *.ubuntu.com to the filter for Ubuntu updates to work.

## Description

Add *.ubuntu.com to the filter for Ubuntu updates to work.

